### PR TITLE
fix: Fabric keybinding is now fabric keymapping

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,7 +36,7 @@
   "depends": {
     "fabricloader": ">=${loader_version}",
     "minecraft": "${compatible_minecraft_version}",
-    "fabric-key-binding-api-v1": "*",
+    "fabric-key-mapping-api-v1": "*",
     "fabric-lifecycle-events-v1": "*"
   }
 }


### PR DESCRIPTION
Fixes crash on 26.1.2.

See:
https://github.com/FabricMC/fabric-api/commit/574290ba3620108f5ae11b6edc22b567ebbc853b
https://github.com/FabricMC/fabric-api/pull/5060